### PR TITLE
Fix quotes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 CC = cc
-CFLAGS = -Wall -Wextra -Werror -I./includes
-LDFLAGS = -lreadline
+CFLAGS = -Wall -Wextra -Werror
+READLINE_PATH = /opt/homebrew/opt/readline
+LDFLAGS = -L/opt/homebrew/opt/readline/lib -lreadline
 
 SRC_DIR = srcs
 OBJ_DIR = obj
@@ -42,12 +43,13 @@ all: $(LIBFT) $(NAME)
 $(LIBFT):
 	make -C libft
 
-$(NAME): $(OBJS)
-	$(CC) $(CFLAGS) $(OBJS) $(LIBFT) -L/opt/homebrew/lib -lreadline -o $(NAME)
-
 $(OBJ_DIR)/%.o: $(SRC_DIR)/%.c
 	@mkdir -p $(@D)
-	$(CC) $(CFLAGS) -c $< -o $@
+	$(CC) $(CFLAGS) -c $< -o $@ -Iincludes -I$(READLINE_PATH)/include
+
+$(NAME): $(OBJS)
+	$(CC) $(CFLAGS) $(OBJS) $(LIBFT) $(LDFLAGS) -o $(NAME)
+
 
 clean:
 	rm -rf $(OBJ_DIR)

--- a/includes/shell.h
+++ b/includes/shell.h
@@ -16,21 +16,21 @@
 # include "../libft/include/libft.h"
 # include "execution.h"
 # include "parser.h"
-# include <linux/limits.h>
+// # include <linux/limits.h>
 # include <errno.h>
 # include <fcntl.h>
 # include <limits.h>
-# include <readline/history.h>
-# include <readline/readline.h>
+# include <stdio.h>
 # include <signal.h>
 # include <stdbool.h>
-# include <stdio.h>
 # include <stdlib.h>
 # include <string.h>
 # include <sys/stat.h>
 # include <sys/types.h>
 # include <sys/wait.h>
 # include <unistd.h>
+# include <readline/history.h>
+# include <readline/readline.h>
 
 // SIGNALS
 void	setup_signals(void);

--- a/srcs/main.c
+++ b/srcs/main.c
@@ -35,7 +35,9 @@ int	main(int argc, char **argv, char **envp)
 		free_tokens(tokens);
 		// print_ast(ast, 0);
 		exec(ast, copy_env);
+		free_ast(ast);
 		free(input);
 	}
+	rl_clear_history();
 	return (0);
 }

--- a/srcs/parser/ast.c
+++ b/srcs/parser/ast.c
@@ -51,10 +51,18 @@ t_tree	*create_ast_node(t_node_type type, char **argv, int argc,
  */
 void	free_ast(t_tree *root)
 {
+	int	i;
+
+	i = 0;
 	if (!root)
 		return ;
 	free_ast(root->left);
 	free_ast(root->right);
+	while (root->argv[i])
+	{
+		free(root->argv[i]);
+		i++;
+	}
 	free(root->argv);
 	free(root);
 }

--- a/srcs/parser/lexer.c
+++ b/srcs/parser/lexer.c
@@ -108,7 +108,6 @@ t_token	*lexer_tokenizer(char *input)
 		if (!new_token)
 			break ;
 		append_token(&head, &current, new_token);
-		input++;
 	}
 	if (current != NULL)
 		current->next = create_token(ft_strdup("\0"), TKN_END);


### PR DESCRIPTION
- Fix Makefile to work in mac (my mac).
- Add correct freeing in the ast's argv array.
- Fix extra character when using commands without arguments (e.x ls or cd).